### PR TITLE
Implement a function to read all rows from a table

### DIFF
--- a/ignite-rs/src/api/key_value.rs
+++ b/ignite-rs/src/api/key_value.rs
@@ -37,6 +37,7 @@ pub(crate) enum CacheReq<'a, K: WritableType, V: WritableType> {
     RemoveKeys(i32, &'a [K]),
     RemoveAll(i32),
     QueryScan(i32, i32),                    // cache ID, page size,
+    QueryScanCursorGetPage(i64),            // cursor ID
     QueryScanSql(i32, i32, String, String), // cache ID, page size, table/type, sql
     QueryScanSqlFields(i32, i32, String),   // cache ID, page size, sql
 }
@@ -119,6 +120,11 @@ impl<'a, K: WritableType, V: WritableType> WriteableReq for CacheReq<'a, K, V> {
                 write_i32(writer, *pg_sz)?;
                 write_i32(writer, -1)?; // negative to query entire cache
                 write_bool(writer, false)?; // can be executed anywhere?
+                Ok(())
+            }
+            // https://ignite.apache.org/docs/latest/binary-client-protocol/sql-and-scan-queries#op_query_scan_cursor_get_page
+            CacheReq::QueryScanCursorGetPage(cursor_id) => {
+                write_i64(writer, *cursor_id)?;
                 Ok(())
             }
             // https://ignite.apache.org/docs/latest/binary-client-protocol/sql-and-scan-queries#op_query_sql
@@ -226,6 +232,9 @@ impl<'a, K: WritableType, V: WritableType> WriteableReq for CacheReq<'a, K, V> {
                 + size_of::<i32>() // Partition count
                 + size_of::<u8>() // local only flag
             }
+            CacheReq::QueryScanCursorGetPage(_) => {
+                size_of::<i64>() // Cursor ID
+            }
             CacheReq::QueryScanSql(_, _, table, sql) => {
                 CACHE_ID_MAGIC_BYTE_SIZE
                     + size_of::<i32>() + table.len() + size_of::<u8>()
@@ -287,12 +296,14 @@ impl<K: ReadableType, V: ReadableType> ReadableReq for CachePairsResp<K, V> {
 }
 
 pub(crate) struct QueryScanResp<K: ReadableType, V: ReadableType> {
+    pub(crate) cursor_id: i64,
     pub(crate) val: Vec<(Option<K>, Option<V>)>,
+    pub(crate) more: bool,
 }
 
 impl<K: ReadableType, V: ReadableType> ReadableReq for QueryScanResp<K, V> {
     fn read(reader: &mut impl Read) -> IgniteResult<Self> {
-        let _cursor_id = read_i64(reader)?;
+        let cursor_id = read_i64(reader)?;
         let count = read_i32(reader)?;
         let mut pairs: Vec<(Option<K>, Option<V>)> = Vec::new();
         for _ in 0..count {
@@ -300,8 +311,37 @@ impl<K: ReadableType, V: ReadableType> ReadableReq for QueryScanResp<K, V> {
             let val = V::read(reader)?;
             pairs.push((key, val));
         }
-        let _more = read_bool(reader)?; // TODO: get more results
-        Ok(QueryScanResp { val: pairs })
+        let more = read_bool(reader)?;
+        Ok(QueryScanResp {
+            cursor_id,
+            val: pairs,
+            more,
+        })
+    }
+}
+
+pub(crate) struct QueryScanCursorGetPageResp<K: ReadableType, V: ReadableType> {
+    pub(crate) cursor_id: i64,
+    pub(crate) val: Vec<(Option<K>, Option<V>)>,
+    pub(crate) more: bool,
+}
+
+impl<K: ReadableType, V: ReadableType> ReadableReq for QueryScanCursorGetPageResp<K, V> {
+    fn read(reader: &mut impl Read) -> IgniteResult<Self> {
+        let cursor_id = read_i64(reader)?;
+        let count = read_i64(reader)?;
+        let mut pairs: Vec<(Option<K>, Option<V>)> = Vec::new();
+        for _ in 0..count {
+            let key = K::read(reader)?;
+            let val = V::read(reader)?;
+            pairs.push((key, val));
+        }
+        let more = read_bool(reader)?;
+        Ok(QueryScanCursorGetPageResp {
+            cursor_id,
+            val: pairs,
+            more,
+        })
     }
 }
 

--- a/ignite-rs/src/api/mod.rs
+++ b/ignite-rs/src/api/mod.rs
@@ -35,6 +35,7 @@ pub(crate) enum OpCode {
     CacheGetSize = 1020,
     // sql & scan queries - https://ignite.apache.org/docs/latest/binary-client-protocol/sql-and-scan-queries
     QueryScan = 2000,
+    QueryScanCursorGetPage = 2001,
     QuerySql = 2002,
     QuerySqlFields = 2004,
     TxStart = 4000,

--- a/ignite-rs/src/cache.rs
+++ b/ignite-rs/src/cache.rs
@@ -315,9 +315,9 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             OpCode::QueryScan,
             CacheReq::QueryScan::<K, V>(self.id, page_size),
         )?;
+        let cursor_id = resp.cursor_id;
         let mut val = resp.val;
         let mut more_available = resp.more;
-        let mut cursor_id = resp.cursor_id;
         while more_available {
             let page_resp: QueryScanCursorGetPageResp<K, V> = self.conn.send_and_read(
                 OpCode::QueryScanCursorGetPage,
@@ -325,7 +325,6 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             )?;
             val.extend(page_resp.val);
             more_available = page_resp.more;
-            cursor_id = page_resp.cursor_id;
         }
         Ok(val)
     }


### PR DESCRIPTION
The existing `query_scan()` function can **only read a fixed number of rows** from a table.

This PR adds a new `query_scan_all()` function which **can read all rows** from a table.

Technical details:
- `query_scan()` uses the `OP_QUERY_SCAN` operation to read one page of rows.
- `query_scan_all()` uses the `OP_QUERY_SCAN` operation followed by zero or more invocations of `OP_QUERY_SCAN_CURSOR_GET_PAGE` to retrieve all pages of rows.

Official specification: https://ignite.apache.org/docs/2.14.0/binary-client-protocol/sql-and-scan-queries
Note that the specification of the `OP_QUERY_SCAN_CURSOR_GET_PAGE` response is incorrect and doesn't match the actual response from Ignite (https://issues.apache.org/jira/browse/IGNITE-8411).