### PR TITLE
feat: better error handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.features": [],
+}

--- a/ignite-rs/Cargo.toml
+++ b/ignite-rs/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["database"]
 bufstream = "0.1.4"
 hex-literal = "0.4.1"
 num-bigint = "0.4.3"
+snafu = "0.8.5"
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/ignite-rs/src/api/cache_config.rs
+++ b/ignite-rs/src/api/cache_config.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 
 use crate::cache::CacheConfiguration;
-use crate::error::{IgniteError, IgniteResult};
+use crate::error::{IgniteError, Result};
 use crate::protocol::cache_config::{get_cache_configuration_bytes, read_cache_configuration};
 use crate::protocol::{
     read_i32, write_bool, write_i32, write_i64, write_null, write_string_type_code, write_u8,
@@ -38,7 +38,7 @@ pub(crate) struct ClientIntResp {
 }
 
 impl ReadableReq for ClientIntResp {
-    fn read(reader: &mut impl Read) -> IgniteResult<Self> {
+    fn read(reader: &mut impl Read) -> Result<Self> {
         let value = read_i32(reader)?;
 
         Ok(ClientIntResp { value })
@@ -83,7 +83,7 @@ pub(crate) struct CacheGetNamesResp {
 }
 
 impl ReadableReq for CacheGetNamesResp {
-    fn read(reader: &mut impl Read) -> IgniteResult<Self> {
+    fn read(reader: &mut impl Read) -> Result<Self> {
         // cache count
         let count = read_i32(reader)?;
 
@@ -199,7 +199,7 @@ pub(crate) struct CacheGetConfigResp {
 }
 
 impl ReadableReq for CacheGetConfigResp {
-    fn read(reader: &mut impl Read) -> IgniteResult<Self> {
+    fn read(reader: &mut impl Read) -> Result<Self> {
         let _ = read_i32(reader)?;
         let config = read_cache_configuration(reader)?;
         Ok(CacheGetConfigResp { config })

--- a/ignite-rs/src/api/cache_config.rs
+++ b/ignite-rs/src/api/cache_config.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 
 use crate::cache::CacheConfiguration;
-use crate::error::{IgniteError, Result};
+use crate::error::{Error, Result};
 use crate::protocol::cache_config::{get_cache_configuration_bytes, read_cache_configuration};
 use crate::protocol::{
     read_i32, write_bool, write_i32, write_i64, write_null, write_string_type_code, write_u8,
@@ -90,7 +90,7 @@ impl ReadableReq for CacheGetNamesResp {
         let mut names = Vec::<String>::new();
         for _ in 0..count {
             match String::read(reader)? {
-                None => return Err(IgniteError::from("NULL is not expected")),
+                None => return Err(Error::from("NULL is not expected")),
                 Some(n) => names.push(n),
             };
         }

--- a/ignite-rs/src/api/key_value.rs
+++ b/ignite-rs/src/api/key_value.rs
@@ -1,5 +1,5 @@
 use crate::cache::CachePeekMode;
-use crate::error::IgniteResult;
+use crate::error::Result;
 use crate::protocol::{
     read_bool, read_i32, read_i64, write_bool, write_i32, write_i64, write_i8, write_null,
     write_string, write_u8, TypeCode,
@@ -263,7 +263,7 @@ pub(crate) struct CacheDataObjectResp<V: ReadableType> {
 }
 
 impl<V: ReadableType> ReadableReq for CacheDataObjectResp<V> {
-    fn read(reader: &mut impl Read) -> IgniteResult<Self> {
+    fn read(reader: &mut impl Read) -> Result<Self> {
         let val = V::read(reader)?;
         Ok(CacheDataObjectResp { val })
     }
@@ -274,7 +274,7 @@ pub(crate) struct CachePairsResp<K: ReadableType, V: ReadableType> {
 }
 
 impl<K: ReadableType, V: ReadableType> ReadableReq for CachePairsResp<K, V> {
-    fn read(reader: &mut impl Read) -> IgniteResult<Self> {
+    fn read(reader: &mut impl Read) -> Result<Self> {
         let count = read_i32(reader)?;
         let mut pairs: Vec<(Option<K>, Option<V>)> = Vec::new();
         for _ in 0..count {
@@ -291,7 +291,7 @@ pub(crate) struct QueryScanResp<K: ReadableType, V: ReadableType> {
 }
 
 impl<K: ReadableType, V: ReadableType> ReadableReq for QueryScanResp<K, V> {
-    fn read(reader: &mut impl Read) -> IgniteResult<Self> {
+    fn read(reader: &mut impl Read) -> Result<Self> {
         let _cursor_id = read_i64(reader)?;
         let count = read_i32(reader)?;
         let mut pairs: Vec<(Option<K>, Option<V>)> = Vec::new();
@@ -310,7 +310,7 @@ pub(crate) struct CacheSizeResp {
 }
 
 impl ReadableReq for CacheSizeResp {
-    fn read(reader: &mut impl Read) -> IgniteResult<Self> {
+    fn read(reader: &mut impl Read) -> Result<Self> {
         let size = read_i64(reader)?;
         Ok(CacheSizeResp { size })
     }
@@ -321,7 +321,7 @@ pub(crate) struct CacheBoolResp {
 }
 
 impl ReadableReq for CacheBoolResp {
-    fn read(reader: &mut impl Read) -> IgniteResult<Self> {
+    fn read(reader: &mut impl Read) -> Result<Self> {
         let flag = read_bool(reader)?;
         Ok(CacheBoolResp { flag })
     }

--- a/ignite-rs/src/cache.rs
+++ b/ignite-rs/src/cache.rs
@@ -12,7 +12,7 @@ use crate::cache::PartitionLossPolicy::{
 };
 use crate::cache::RebalanceMode::Async;
 use crate::cache::WriteSynchronizationMode::{FullAsync, FullSync, PrimarySync};
-use crate::error::{IgniteError, IgniteResult};
+use crate::error::{IgniteError, Result};
 
 use crate::api::OpCode;
 use crate::connection::Connection;
@@ -296,7 +296,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
     }
 
     /// https://ignite.apache.org/docs/latest/binary-client-protocol/sql-and-scan-queries#op_query_scan
-    pub fn query_scan(&self, page_size: i32) -> IgniteResult<Vec<(Option<K>, Option<V>)>> {
+    pub fn query_scan(&self, page_size: i32) -> Result<Vec<(Option<K>, Option<V>)>> {
         self.conn
             .send_and_read(
                 OpCode::QueryScan,
@@ -311,7 +311,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
         page_size: i32,
         type_name: &str,
         sql: &str,
-    ) -> IgniteResult<Vec<(Option<K>, Option<V>)>> {
+    ) -> Result<Vec<(Option<K>, Option<V>)>> {
         self.conn
             .send_and_read(
                 OpCode::QuerySql,
@@ -328,8 +328,8 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
     pub fn query_scan_dyn(
         &self,
         page_size: i32,
-        cb: &mut dyn Fn(&mut dyn Read, i32) -> IgniteResult<()>,
-    ) -> IgniteResult<bool> {
+        cb: &mut dyn Fn(&mut dyn Read, i32) -> Result<()>,
+    ) -> Result<bool> {
         let req = CacheReq::QueryScan::<K, V>(self.id, page_size);
         let more: Arc<Mutex<Option<bool>>> = Arc::new(Mutex::new(None));
         self.conn
@@ -347,31 +347,31 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
         Ok(more)
     }
 
-    pub fn get(&self, key: &K) -> IgniteResult<Option<V>> {
+    pub fn get(&self, key: &K) -> Result<Option<V>> {
         self.conn
             .send_and_read(OpCode::CacheGet, CacheReq::Get::<K, V>(self.id, key))
             .map(|resp: CacheDataObjectResp<V>| resp.val)
     }
 
-    pub fn get_all(&self, keys: &[K]) -> IgniteResult<Vec<(Option<K>, Option<V>)>> {
+    pub fn get_all(&self, keys: &[K]) -> Result<Vec<(Option<K>, Option<V>)>> {
         self.conn
             .send_and_read(OpCode::CacheGetAll, CacheReq::GetAll::<K, V>(self.id, keys))
             .map(|resp: CachePairsResp<K, V>| resp.val)
     }
 
-    pub fn put(&self, key: &K, value: &V) -> IgniteResult<()> {
+    pub fn put(&self, key: &K, value: &V) -> Result<()> {
         self.conn
             .send(OpCode::CachePut, CacheReq::Put::<K, V>(self.id, key, value))
     }
 
-    pub fn put_all(&self, pairs: &[(K, V)]) -> IgniteResult<()> {
+    pub fn put_all(&self, pairs: &[(K, V)]) -> Result<()> {
         self.conn.send(
             OpCode::CachePutAll,
             CacheReq::PutAll::<K, V>(self.id, pairs),
         )
     }
 
-    pub fn contains_key(&self, key: &K) -> IgniteResult<bool> {
+    pub fn contains_key(&self, key: &K) -> Result<bool> {
         self.conn
             .send_and_read(
                 OpCode::CacheContainsKey,
@@ -380,7 +380,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheBoolResp| resp.flag)
     }
 
-    pub fn contains_keys(&self, keys: &[K]) -> IgniteResult<bool> {
+    pub fn contains_keys(&self, keys: &[K]) -> Result<bool> {
         self.conn
             .send_and_read(
                 OpCode::CacheContainsKeys,
@@ -389,7 +389,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheBoolResp| resp.flag)
     }
 
-    pub fn get_and_put(&self, key: &K, value: &V) -> IgniteResult<Option<V>> {
+    pub fn get_and_put(&self, key: &K, value: &V) -> Result<Option<V>> {
         self.conn
             .send_and_read(
                 OpCode::CacheGetAndPut,
@@ -398,7 +398,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheDataObjectResp<V>| resp.val)
     }
 
-    pub fn get_and_replace(&self, key: &K, value: &V) -> IgniteResult<Option<V>> {
+    pub fn get_and_replace(&self, key: &K, value: &V) -> Result<Option<V>> {
         self.conn
             .send_and_read(
                 OpCode::CacheGetAndReplace,
@@ -407,7 +407,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheDataObjectResp<V>| resp.val)
     }
 
-    pub fn get_and_remove(&self, key: &K) -> IgniteResult<Option<V>> {
+    pub fn get_and_remove(&self, key: &K) -> Result<Option<V>> {
         self.conn
             .send_and_read(
                 OpCode::CacheGetAndRemove,
@@ -416,7 +416,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheDataObjectResp<V>| resp.val)
     }
 
-    pub fn put_if_absent(&self, key: &K, value: &V) -> IgniteResult<bool> {
+    pub fn put_if_absent(&self, key: &K, value: &V) -> Result<bool> {
         self.conn
             .send_and_read(
                 OpCode::CachePutIfAbsent,
@@ -425,7 +425,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheBoolResp| resp.flag)
     }
 
-    pub fn get_and_put_if_absent(&self, key: &K, value: &V) -> IgniteResult<Option<V>> {
+    pub fn get_and_put_if_absent(&self, key: &K, value: &V) -> Result<Option<V>> {
         self.conn
             .send_and_read(
                 OpCode::CacheGetAndPutIfAbsent,
@@ -434,7 +434,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheDataObjectResp<V>| resp.val)
     }
 
-    pub fn replace(&self, key: &K, value: &V) -> IgniteResult<bool> {
+    pub fn replace(&self, key: &K, value: &V) -> Result<bool> {
         self.conn
             .send_and_read(
                 OpCode::CacheReplace,
@@ -443,7 +443,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheBoolResp| resp.flag)
     }
 
-    pub fn replace_if_equals(&self, key: &K, old: &V, new: &V) -> IgniteResult<bool> {
+    pub fn replace_if_equals(&self, key: &K, old: &V, new: &V) -> Result<bool> {
         self.conn
             .send_and_read(
                 OpCode::CacheReplaceIfEquals,
@@ -452,26 +452,26 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheBoolResp| resp.flag)
     }
 
-    pub fn clear(&self) -> IgniteResult<()> {
+    pub fn clear(&self) -> Result<()> {
         self.conn
             .send(OpCode::CacheClear, CacheReq::Clear::<K, V>(self.id))
     }
 
-    pub fn clear_key(&self, key: &K) -> IgniteResult<()> {
+    pub fn clear_key(&self, key: &K) -> Result<()> {
         self.conn.send(
             OpCode::CacheClearKey,
             CacheReq::ClearKey::<K, V>(self.id, key),
         )
     }
 
-    pub fn clear_keys(&self, keys: &[K]) -> IgniteResult<()> {
+    pub fn clear_keys(&self, keys: &[K]) -> Result<()> {
         self.conn.send(
             OpCode::CacheClearKeys,
             CacheReq::ClearKeys::<K, V>(self.id, keys),
         )
     }
 
-    pub fn remove_key(&self, key: &K) -> IgniteResult<bool> {
+    pub fn remove_key(&self, key: &K) -> Result<bool> {
         self.conn
             .send_and_read(
                 OpCode::CacheRemoveKey,
@@ -480,7 +480,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheBoolResp| resp.flag)
     }
 
-    pub fn remove_if_equals(&self, key: &K, value: &V) -> IgniteResult<bool> {
+    pub fn remove_if_equals(&self, key: &K, value: &V) -> Result<bool> {
         self.conn
             .send_and_read(
                 OpCode::CacheRemoveIfEquals,
@@ -489,7 +489,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheBoolResp| resp.flag)
     }
 
-    pub fn get_size(&self) -> IgniteResult<i64> {
+    pub fn get_size(&self) -> Result<i64> {
         let modes = Vec::new();
         self.conn
             .send_and_read(
@@ -499,7 +499,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheSizeResp| resp.size)
     }
 
-    pub fn get_size_peek_mode(&self, mode: CachePeekMode) -> IgniteResult<i64> {
+    pub fn get_size_peek_mode(&self, mode: CachePeekMode) -> Result<i64> {
         let modes = vec![mode];
         self.conn
             .send_and_read(
@@ -509,7 +509,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheSizeResp| resp.size)
     }
 
-    pub fn get_size_peek_modes(&self, modes: Vec<CachePeekMode>) -> IgniteResult<i64> {
+    pub fn get_size_peek_modes(&self, modes: Vec<CachePeekMode>) -> Result<i64> {
         self.conn
             .send_and_read(
                 OpCode::CacheGetSize,
@@ -518,14 +518,14 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
             .map(|resp: CacheSizeResp| resp.size)
     }
 
-    pub fn remove_keys(&self, keys: &[K]) -> IgniteResult<()> {
+    pub fn remove_keys(&self, keys: &[K]) -> Result<()> {
         self.conn.send(
             OpCode::CacheRemoveKeys,
             CacheReq::RemoveKeys::<K, V>(self.id, keys),
         )
     }
 
-    pub fn remove_all(&self) -> IgniteResult<()> {
+    pub fn remove_all(&self) -> Result<()> {
         self.conn
             .send(OpCode::CacheRemoveAll, CacheReq::RemoveAll::<K, V>(self.id))
     }

--- a/ignite-rs/src/cache.rs
+++ b/ignite-rs/src/cache.rs
@@ -12,7 +12,7 @@ use crate::cache::PartitionLossPolicy::{
 };
 use crate::cache::RebalanceMode::Async;
 use crate::cache::WriteSynchronizationMode::{FullAsync, FullSync, PrimarySync};
-use crate::error::{IgniteError, Result};
+use crate::error::{Error, Result};
 
 use crate::api::OpCode;
 use crate::connection::Connection;
@@ -28,13 +28,13 @@ pub enum AtomicityMode {
 }
 
 impl TryFrom<i32> for AtomicityMode {
-    type Error = IgniteError;
+    type Error = Error;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(Transactional),
             1 => Ok(Atomic),
-            _ => Err(IgniteError::from("Cannot read AtomicityMode")),
+            _ => Err(Error::from("Cannot read AtomicityMode")),
         }
     }
 }
@@ -47,14 +47,14 @@ pub enum CacheMode {
 }
 
 impl TryFrom<i32> for CacheMode {
-    type Error = IgniteError;
+    type Error = Error;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(Local),
             1 => Ok(Replicated),
             2 => Ok(Partitioned),
-            _ => Err(IgniteError::from("Cannot read CacheMode")),
+            _ => Err(Error::from("Cannot read CacheMode")),
         }
     }
 }
@@ -69,7 +69,7 @@ pub enum PartitionLossPolicy {
 }
 
 impl TryFrom<i32> for PartitionLossPolicy {
-    type Error = IgniteError;
+    type Error = Error;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
@@ -78,7 +78,7 @@ impl TryFrom<i32> for PartitionLossPolicy {
             2 => Ok(ReadWriteSafe),
             3 => Ok(ReadWriteAll),
             4 => Ok(Ignore),
-            _ => Err(IgniteError::from("Cannot read PartitionLossPolicy")),
+            _ => Err(Error::from("Cannot read PartitionLossPolicy")),
         }
     }
 }
@@ -91,14 +91,14 @@ pub enum RebalanceMode {
 }
 
 impl TryFrom<i32> for RebalanceMode {
-    type Error = IgniteError;
+    type Error = Error;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(RebalanceMode::Sync),
             1 => Ok(Async),
             2 => Ok(RebalanceMode::None),
-            _ => Err(IgniteError::from("Cannot read RebalanceMode")),
+            _ => Err(Error::from("Cannot read RebalanceMode")),
         }
     }
 }
@@ -111,14 +111,14 @@ pub enum WriteSynchronizationMode {
 }
 
 impl TryFrom<i32> for WriteSynchronizationMode {
-    type Error = IgniteError;
+    type Error = Error;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(FullSync),
             1 => Ok(FullAsync),
             2 => Ok(PrimarySync),
-            _ => Err(IgniteError::from("Cannot read WriteSynchronizationMode")),
+            _ => Err(Error::from("Cannot read WriteSynchronizationMode")),
         }
     }
 }
@@ -145,14 +145,14 @@ pub enum IndexType {
 }
 
 impl TryFrom<u8> for IndexType {
-    type Error = IgniteError;
+    type Error = Error;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(Sorted),
             1 => Ok(Fulltext),
             2 => Ok(GeoSpatial),
-            _ => Err(IgniteError::from("Cannot read IndexType")),
+            _ => Err(Error::from("Cannot read IndexType")),
         }
     }
 }
@@ -343,7 +343,7 @@ impl<K: WritableType + ReadableType, V: WritableType + ReadableType> Cache<K, V>
         let more = more
             .lock()
             .unwrap()
-            .ok_or(IgniteError::from("Callback not invoked!"))?;
+            .ok_or(Error::from("Callback not invoked!"))?;
         Ok(more)
     }
 

--- a/ignite-rs/src/connection.rs
+++ b/ignite-rs/src/connection.rs
@@ -61,7 +61,7 @@ impl Connection {
 
     /// Send message and read response header. Acquires lock
     pub(crate) fn send(&self, op_code: OpCode, data: impl WriteableReq) -> Result<()> {
-        let sock_lock = &mut *self.stream.lock().unwrap(); //acquire lock on socket
+        let sock_lock = &mut *self.stream.lock()?; //acquire lock on socket
         Connection::send_safe(sock_lock, op_code, data)
     }
 
@@ -71,7 +71,7 @@ impl Connection {
         op_code: OpCode,
         data: impl WriteableReq,
     ) -> Result<T> {
-        let sock_lock = &mut *self.stream.lock().unwrap(); //acquire lock on socket
+        let sock_lock = &mut *self.stream.lock()?; //acquire lock on socket
         Connection::send_and_read_safe(sock_lock, op_code, data)
     }
 
@@ -82,7 +82,7 @@ impl Connection {
         req: impl WriteableReq,
         cb: &mut dyn Fn(&mut dyn Read) -> Result<()>,
     ) -> Result<()> {
-        let buf = &mut *self.stream.lock().unwrap(); //acquire lock on socket
+        let buf = &mut *self.stream.lock()?; //acquire lock on socket
         Connection::send_safe(buf, op_code, req)?; //send request and read the response
         cb(&mut Box::new(buf))?;
         Ok(())

--- a/ignite-rs/src/connection.rs
+++ b/ignite-rs/src/connection.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use std::net::TcpStream;
 
 use crate::api::OpCode;
-use crate::error::{IgniteError, Result};
+use crate::error::{Error, Result};
 use crate::handshake::handshake;
 use crate::protocol::Flag::{Failure, Success};
 use crate::protocol::{read_i32, read_i64, write_i16, write_i32, write_i64, Flag};
@@ -55,7 +55,7 @@ impl Connection {
                     Err(err) => Err(err),
                 }
             }
-            Err(err) => Err(IgniteError::from(err)),
+            Err(err) => Err(Error::from(err)),
         }
     }
 
@@ -105,7 +105,7 @@ impl Connection {
         //read response
         match Connection::read_resp_header(con)? {
             Flag::Success => Ok(()),
-            Flag::Failure { err_msg } => Err(IgniteError::from(err_msg.as_str())),
+            Flag::Failure { err_msg } => Err(Error::from(err_msg.as_str())),
         }
     }
 

--- a/ignite-rs/src/connection.rs
+++ b/ignite-rs/src/connection.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use std::net::TcpStream;
 
 use crate::api::OpCode;
-use crate::error::{IgniteError, IgniteResult};
+use crate::error::{IgniteError, Result};
 use crate::handshake::handshake;
 use crate::protocol::Flag::{Failure, Success};
 use crate::protocol::{read_i32, read_i64, write_i16, write_i32, write_i64, Flag};
@@ -30,7 +30,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub(crate) fn new(conf: &ClientConfig) -> IgniteResult<Connection> {
+    pub(crate) fn new(conf: &ClientConfig) -> Result<Connection> {
         match TcpStream::connect(&conf.addr) {
             Ok(stream) => {
                 // apply tcp configs
@@ -60,7 +60,7 @@ impl Connection {
     }
 
     /// Send message and read response header. Acquires lock
-    pub(crate) fn send(&self, op_code: OpCode, data: impl WriteableReq) -> IgniteResult<()> {
+    pub(crate) fn send(&self, op_code: OpCode, data: impl WriteableReq) -> Result<()> {
         let sock_lock = &mut *self.stream.lock().unwrap(); //acquire lock on socket
         Connection::send_safe(sock_lock, op_code, data)
     }
@@ -70,7 +70,7 @@ impl Connection {
         &self,
         op_code: OpCode,
         data: impl WriteableReq,
-    ) -> IgniteResult<T> {
+    ) -> Result<T> {
         let sock_lock = &mut *self.stream.lock().unwrap(); //acquire lock on socket
         Connection::send_and_read_safe(sock_lock, op_code, data)
     }
@@ -80,8 +80,8 @@ impl Connection {
         &self,
         op_code: OpCode,
         req: impl WriteableReq,
-        cb: &mut dyn Fn(&mut dyn Read) -> IgniteResult<()>,
-    ) -> IgniteResult<()> {
+        cb: &mut dyn Fn(&mut dyn Read) -> Result<()>,
+    ) -> Result<()> {
         let buf = &mut *self.stream.lock().unwrap(); //acquire lock on socket
         Connection::send_safe(buf, op_code, req)?; //send request and read the response
         cb(&mut Box::new(buf))?;
@@ -92,7 +92,7 @@ impl Connection {
         con: &mut RW,
         op_code: OpCode,
         payload: impl WriteableReq,
-    ) -> IgniteResult<()> {
+    ) -> Result<()> {
         // write common message header
         Connection::write_req_header(con, payload.size(), op_code as i16)?;
 
@@ -113,7 +113,7 @@ impl Connection {
         buf: &mut RW,
         op_code: OpCode,
         data: impl WriteableReq,
-    ) -> IgniteResult<T> {
+    ) -> Result<T> {
         Connection::send_safe(buf, op_code, data)?; //send request and read the response
         T::read(buf) //unpack the input bytes into an actual type
     }
@@ -131,7 +131,7 @@ impl Connection {
     }
 
     /// Reads standard response header
-    fn read_resp_header(reader: &mut impl Read) -> IgniteResult<Flag> {
+    fn read_resp_header(reader: &mut impl Read) -> Result<Flag> {
         let _length = read_i32(reader)?;
         let _req_id = read_i64(reader)?;
         let status = read_i32(reader)?;
@@ -150,7 +150,7 @@ impl Connection {
     fn wrap_tls_stream(
         conf: &(rustls::ClientConfig, String),
         stream: TcpStream,
-    ) -> IgniteResult<rustls::StreamOwned<rustls::ClientSession, TcpStream>> {
+    ) -> Result<rustls::StreamOwned<rustls::ClientSession, TcpStream>> {
         let hostname = webpki::DNSNameRef::try_from_ascii_str(&conf.1)?;
         let tls_session = rustls::ClientSession::new(&Arc::new(conf.0.clone()), hostname);
         let tls_stream = rustls::StreamOwned::new(tls_session, stream);

--- a/ignite-rs/src/error.rs
+++ b/ignite-rs/src/error.rs
@@ -1,22 +1,14 @@
-use std::fmt::{Display, Formatter};
+use snafu::Snafu;
+use std::convert;
 use std::io::Error as IoError;
-use std::{convert, error};
 #[cfg(feature = "ssl")]
 use webpki::InvalidDNSNameError;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug)]
+#[derive(Snafu, Debug)]
 pub struct Error {
     pub(crate) desc: String,
-}
-
-impl error::Error for Error {}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.desc)
-    }
 }
 
 impl convert::From<IoError> for Error {

--- a/ignite-rs/src/error.rs
+++ b/ignite-rs/src/error.rs
@@ -4,42 +4,42 @@ use std::{convert, error};
 #[cfg(feature = "ssl")]
 use webpki::InvalidDNSNameError;
 
-pub type Result<T, E = IgniteError> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug)]
-pub struct IgniteError {
+pub struct Error {
     pub(crate) desc: String,
 }
 
-impl error::Error for IgniteError {}
+impl error::Error for Error {}
 
-impl Display for IgniteError {
+impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.desc)
     }
 }
 
-impl convert::From<IoError> for IgniteError {
+impl convert::From<IoError> for Error {
     fn from(e: IoError) -> Self {
-        IgniteError {
+        Error {
             desc: e.to_string(),
         }
     }
 }
 
-impl convert::From<&str> for IgniteError {
+impl convert::From<&str> for Error {
     fn from(desc: &str) -> Self {
-        IgniteError {
+        Error {
             desc: String::from(desc),
         }
     }
 }
 
-impl convert::From<Option<String>> for IgniteError {
+impl convert::From<Option<String>> for Error {
     fn from(desc: Option<String>) -> Self {
         match desc {
-            Some(desc) => IgniteError { desc },
-            None => IgniteError {
+            Some(desc) => Error { desc },
+            None => Error {
                 desc: "Ignite client error! No description provided".to_owned(),
             },
         }
@@ -47,9 +47,9 @@ impl convert::From<Option<String>> for IgniteError {
 }
 
 #[cfg(feature = "ssl")]
-impl convert::From<InvalidDNSNameError> for IgniteError {
+impl convert::From<InvalidDNSNameError> for Error {
     fn from(err: InvalidDNSNameError) -> Self {
-        IgniteError {
+        Error {
             desc: err.to_string(),
         }
     }

--- a/ignite-rs/src/error.rs
+++ b/ignite-rs/src/error.rs
@@ -4,7 +4,7 @@ use std::{convert, error};
 #[cfg(feature = "ssl")]
 use webpki::InvalidDNSNameError;
 
-pub type IgniteResult<T> = Result<T, IgniteError>;
+pub type Result<T, E = IgniteError> = std::result::Result<T, E>;
 
 #[derive(Debug)]
 pub struct IgniteError {

--- a/ignite-rs/src/handshake.rs
+++ b/ignite-rs/src/handshake.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 
 use crate::api::OpCode;
-use crate::error::{IgniteError, IgniteResult};
+use crate::error::{IgniteError, Result};
 use crate::protocol::{
     read_i16, read_i32, read_u8, write_i16, write_i32, write_string_type_code, write_u8,
 };
@@ -14,7 +14,7 @@ const V_MAJOR: i16 = 1;
 const V_MINOR: i16 = 2;
 const V_PATCH: i16 = 0;
 
-pub(crate) fn handshake<T: Read + Write>(conn: &mut T, conf: &ClientConfig) -> IgniteResult<()> {
+pub(crate) fn handshake<T: Read + Write>(conn: &mut T, conf: &ClientConfig) -> Result<()> {
     let mut msg_size = MIN_HANDSHAKE_SIZE;
 
     if conf.username.is_some() != conf.password.is_some() {
@@ -58,7 +58,7 @@ pub(crate) fn handshake<T: Read + Write>(conn: &mut T, conf: &ClientConfig) -> I
     }
 }
 
-fn read_handshake_err<T: Read + Write>(conn: &mut T) -> IgniteResult<String> {
+fn read_handshake_err<T: Read + Write>(conn: &mut T) -> Result<String> {
     let major_v = read_i16(conn)?;
     let minor_v = read_i16(conn)?;
     let patch_v = read_i16(conn)?;

--- a/ignite-rs/src/handshake.rs
+++ b/ignite-rs/src/handshake.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 
 use crate::api::OpCode;
-use crate::error::{IgniteError, Result};
+use crate::error::{Error, Result};
 use crate::protocol::{
     read_i16, read_i32, read_u8, write_i16, write_i32, write_string_type_code, write_u8,
 };
@@ -18,7 +18,7 @@ pub(crate) fn handshake<T: Read + Write>(conn: &mut T, conf: &ClientConfig) -> R
     let mut msg_size = MIN_HANDSHAKE_SIZE;
 
     if conf.username.is_some() != conf.password.is_some() {
-        return Err(IgniteError::from("Both username and password expected!"));
+        return Err(Error::from("Both username and password expected!"));
     }
 
     if let Some(ref user) = conf.username {
@@ -52,7 +52,7 @@ pub(crate) fn handshake<T: Read + Write>(conn: &mut T, conf: &ClientConfig) -> R
     match read_u8(conn)? {
         1 => Ok(()),
         _ => match read_handshake_err(conn) {
-            Ok(msg) => Err(IgniteError::from(msg.as_str())),
+            Ok(msg) => Err(Error::from(msg.as_str())),
             Err(err) => Err(err),
         },
     }

--- a/ignite-rs/src/protocol/cache_config.rs
+++ b/ignite-rs/src/protocol/cache_config.rs
@@ -8,7 +8,7 @@ use crate::cache::{
 use crate::cache::{
     CacheConfiguration, CacheKeyConfiguration, QueryEntity, QueryField, QueryIndex,
 };
-use crate::error::IgniteError;
+use crate::error::Error;
 use crate::error::Result;
 use crate::protocol::cache_config::ConfigPropertyCode::*;
 use crate::protocol::{
@@ -199,7 +199,7 @@ pub(crate) fn read_cache_configuration(reader: &mut impl Read) -> Result<CacheCo
         default_lock_timeout_ms: read_i64(reader)?,
         max_concurrent_async_operations: read_i32(reader)?,
         max_query_iterators: read_i32(reader)?,
-        name: String::read(reader)?.ok_or_else(|| IgniteError::from("name is required"))?,
+        name: String::read(reader)?.ok_or_else(|| Error::from("name is required"))?,
         onheap_cache_enabled: read_bool(reader)?,
         partition_loss_policy: PartitionLossPolicy::try_from(read_i32(reader)?)?,
         query_detail_metrics_size: read_i32(reader)?,

--- a/ignite-rs/src/protocol/cache_config.rs
+++ b/ignite-rs/src/protocol/cache_config.rs
@@ -9,7 +9,7 @@ use crate::cache::{
     CacheConfiguration, CacheKeyConfiguration, QueryEntity, QueryField, QueryIndex,
 };
 use crate::error::IgniteError;
-use crate::error::IgniteResult;
+use crate::error::Result;
 use crate::protocol::cache_config::ConfigPropertyCode::*;
 use crate::protocol::{
     read_bool, read_i32, read_i64, read_object, read_u8, write_bool, write_i16, write_i32,
@@ -186,7 +186,7 @@ pub(crate) fn get_cache_configuration_bytes(config: &CacheConfiguration) -> io::
     Ok(bytes)
 }
 
-pub(crate) fn read_cache_configuration(reader: &mut impl Read) -> IgniteResult<CacheConfiguration> {
+pub(crate) fn read_cache_configuration(reader: &mut impl Read) -> Result<CacheConfiguration> {
     let config = CacheConfiguration {
         atomicity_mode: AtomicityMode::try_from(read_i32(reader)?)?,
         num_backup: read_i32(reader)?,
@@ -222,7 +222,7 @@ pub(crate) fn read_cache_configuration(reader: &mut impl Read) -> IgniteResult<C
     Ok(config)
 }
 
-fn read_cache_key_configs(reader: &mut impl Read) -> IgniteResult<Vec<CacheKeyConfiguration>> {
+fn read_cache_key_configs(reader: &mut impl Read) -> Result<Vec<CacheKeyConfiguration>> {
     let count = read_i32(reader)?;
     let mut result = Vec::<CacheKeyConfiguration>::new();
     for _ in 0..count {
@@ -249,7 +249,7 @@ fn write_cache_key_configs(
     Ok(())
 }
 
-fn read_query_entities(reader: &mut impl Read) -> IgniteResult<Vec<QueryEntity>> {
+fn read_query_entities(reader: &mut impl Read) -> Result<Vec<QueryEntity>> {
     let count = read_i32(reader)?;
     let mut result = Vec::<QueryEntity>::new();
     for _ in 0..count {
@@ -292,7 +292,7 @@ fn write_query_entities(writer: &mut dyn Write, entities: &[QueryEntity]) -> io:
     Ok(())
 }
 
-fn read_query_fields(reader: &mut impl Read) -> IgniteResult<Vec<QueryField>> {
+fn read_query_fields(reader: &mut impl Read) -> Result<Vec<QueryField>> {
     let count = read_i32(reader)?;
     let mut result = Vec::<QueryField>::new();
     for _ in 0..count {
@@ -326,7 +326,7 @@ fn write_query_fields(writer: &mut dyn Write, fields: &[QueryField]) -> io::Resu
     Ok(())
 }
 
-fn read_query_field_aliases(reader: &mut impl Read) -> IgniteResult<Vec<(String, String)>> {
+fn read_query_field_aliases(reader: &mut impl Read) -> Result<Vec<(String, String)>> {
     let count = read_i32(reader)?;
     let mut result = Vec::<(String, String)>::new();
     for _ in 0..count {
@@ -346,7 +346,7 @@ fn write_field_aliases(writer: &mut dyn Write, aliases: &[(String, String)]) -> 
     Ok(())
 }
 
-fn read_query_indexes(reader: &mut impl Read) -> IgniteResult<Vec<QueryIndex>> {
+fn read_query_indexes(reader: &mut impl Read) -> Result<Vec<QueryIndex>> {
     let count = read_i32(reader)?;
     let mut result = Vec::<QueryIndex>::new();
     for _ in 0..count {
@@ -375,7 +375,7 @@ fn write_query_indexes(writer: &mut dyn Write, indexes: &[QueryIndex]) -> io::Re
     Ok(())
 }
 
-fn read_query_index_fields(reader: &mut impl Read) -> IgniteResult<Vec<(String, bool)>> {
+fn read_query_index_fields(reader: &mut impl Read) -> Result<Vec<(String, bool)>> {
     let count = read_i32(reader)?;
     let mut result = Vec::<(String, bool)>::new();
     for _ in 0..count {

--- a/ignite-rs/src/protocol/complex_obj.rs
+++ b/ignite-rs/src/protocol/complex_obj.rs
@@ -1,5 +1,5 @@
 use crate::cache::{QueryEntity, QueryField};
-use crate::error::{IgniteError, Result};
+use crate::error::{Error, Result};
 use crate::protocol::{
     read_bool, read_i16, read_i32, read_i64, read_i8, read_string, read_u16, read_u8, write_i16,
     write_i32, write_i64, write_i8, write_null, write_string, write_u16, write_u8, TypeCode,
@@ -205,7 +205,7 @@ impl ReadableType for ComplexObject {
                     (true, false) => 1,
                     (false, true) => 2,
                     (false, false) => 4,
-                    (true, true) => Err(IgniteError::from("Invalid offset flags"))?,
+                    (true, true) => Err(Error::from("Invalid offset flags"))?,
                 };
 
                 // append body
@@ -249,7 +249,7 @@ impl ReadableType for ComplexObject {
                         }
                         _ => {
                             let msg = format!("Unknown type: {:?}", field_type);
-                            Err(IgniteError::from(msg.as_str()))?
+                            Err(Error::from(msg.as_str()))?
                         }
                     };
                     me.values.push(val);
@@ -481,7 +481,7 @@ impl ComplexObjectSchema {
                 // primitive types. Specifically, it is the output of
                 // `System.out.println(byte[].class.getName());`
                 "[B" => IgniteType::Binary,
-                _ => Err(IgniteError::from(
+                _ => Err(Error::from(
                     format!("Unknown field type: {}", f.type_name).as_str(),
                 ))?,
             };

--- a/ignite-rs/src/protocol/complex_obj.rs
+++ b/ignite-rs/src/protocol/complex_obj.rs
@@ -1,5 +1,5 @@
 use crate::cache::{QueryEntity, QueryField};
-use crate::error::{IgniteError, IgniteResult};
+use crate::error::{IgniteError, Result};
 use crate::protocol::{
     read_bool, read_i16, read_i32, read_i64, read_i8, read_string, read_u16, read_u8, write_i16,
     write_i32, write_i64, write_i8, write_null, write_string, write_u16, write_u8, TypeCode,
@@ -137,7 +137,7 @@ impl ComplexObject {
 }
 
 impl ReadableType for ComplexObject {
-    fn read_unwrapped(type_code: TypeCode, reader: &mut impl Read) -> IgniteResult<Option<Self>> {
+    fn read_unwrapped(type_code: TypeCode, reader: &mut impl Read) -> Result<Option<Self>> {
         let mut me = ComplexObject {
             schema: Arc::new(ComplexObjectSchema {
                 type_name: "".to_string(),
@@ -441,7 +441,7 @@ impl ComplexObjectSchema {
     /// Find the key and value DynamicIgniteTypes for a table.
     pub fn infer_schemas(
         entity: &QueryEntity,
-    ) -> IgniteResult<(Arc<ComplexObjectSchema>, Arc<ComplexObjectSchema>)> {
+    ) -> Result<(Arc<ComplexObjectSchema>, Arc<ComplexObjectSchema>)> {
         let key_fields: Vec<_> = entity
             .query_fields
             .iter()
@@ -465,7 +465,7 @@ impl ComplexObjectSchema {
         Ok((Arc::new(k), Arc::new(v)))
     }
 
-    fn convert_fields(qry_fields: &[&QueryField]) -> IgniteResult<Vec<IgniteField>> {
+    fn convert_fields(qry_fields: &[&QueryField]) -> Result<Vec<IgniteField>> {
         let mut fields = vec![];
         for f in qry_fields.iter() {
             let t: IgniteType = match f.type_name.as_str() {

--- a/ignite-rs/src/protocol/data_types.rs
+++ b/ignite-rs/src/protocol/data_types.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use crate::error::{IgniteError, Result};
+use crate::error::{Error, Result};
 use crate::protocol::*;
 use crate::protocol::{read_u8, TypeCode};
 
@@ -176,7 +176,7 @@ impl<T: WritableType + ReadableType> ReadableType for Vec<Option<T>> {
                 }
                 Ok(Some(data))
             }
-            _ => Err(IgniteError::from("Expected Array or Collection!")),
+            _ => Err(Error::from("Expected Array or Collection!")),
         }
     }
 }

--- a/ignite-rs/src/protocol/mod.rs
+++ b/ignite-rs/src/protocol/mod.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::io::{ErrorKind, Read, Write};
 
-use crate::error::{IgniteError, IgniteResult};
+use crate::error::{IgniteError, Result};
 
 use crate::{Enum, ReadableType};
 use std::convert::TryFrom;
@@ -94,7 +94,7 @@ pub(crate) enum Flag {
     Failure { err_msg: String },
 }
 
-fn read_object(reader: &mut impl Read) -> IgniteResult<Option<()>> {
+fn read_object(reader: &mut impl Read) -> Result<Option<()>> {
     let flag = read_u8(reader)?;
     let code = TypeCode::try_from(flag);
     let code = code?;
@@ -107,7 +107,7 @@ fn read_object(reader: &mut impl Read) -> IgniteResult<Option<()>> {
 }
 
 /// Reads data objects that are wrapped in the WrappedData(type code = 27)
-pub fn read_wrapped_data<T: ReadableType>(reader: &mut impl Read) -> IgniteResult<Option<T>> {
+pub fn read_wrapped_data<T: ReadableType>(reader: &mut impl Read) -> Result<Option<T>> {
     let type_code = TypeCode::try_from(read_u8(reader)?)?;
     match type_code {
         TypeCode::WrappedData => {
@@ -123,8 +123,8 @@ pub fn read_wrapped_data<T: ReadableType>(reader: &mut impl Read) -> IgniteResul
 /// Reads data objects that are wrapped in the WrappedData(type code = 27)
 pub fn read_wrapped_data_dyn(
     reader: &mut dyn Read,
-    cb: &mut dyn Fn(&mut dyn Read, i32) -> IgniteResult<()>,
-) -> IgniteResult<()> {
+    cb: &mut dyn Fn(&mut dyn Read, i32) -> Result<()>,
+) -> Result<()> {
     let type_code = TypeCode::try_from(read_u8(reader)?)?;
     match type_code {
         TypeCode::WrappedData => {
@@ -140,8 +140,8 @@ pub fn read_wrapped_data_dyn(
 /// Reads a complex object (type code = 103)
 pub fn read_complex_obj_dyn(
     reader: &mut dyn Read,
-    cb: &mut dyn Fn(&mut dyn Read, i32) -> IgniteResult<()>,
-) -> IgniteResult<()> {
+    cb: &mut dyn Fn(&mut dyn Read, i32) -> Result<()>,
+) -> Result<()> {
     let _ver = read_u8(reader)?; // 1
     let flags = read_u16(reader)?; // 43
     let _type_id = read_i32(reader)?;

--- a/ignite-rs/src/protocol/mod.rs
+++ b/ignite-rs/src/protocol/mod.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::io::{ErrorKind, Read, Write};
 
-use crate::error::{IgniteError, Result};
+use crate::error::{Error, Result};
 
 use crate::{Enum, ReadableType};
 use std::convert::TryFrom;
@@ -52,7 +52,7 @@ pub enum TypeCode {
 }
 
 impl TryFrom<u8> for TypeCode {
-    type Error = IgniteError;
+    type Error = Error;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
@@ -81,7 +81,7 @@ impl TryFrom<u8> for TypeCode {
             27 => Ok(TypeCode::WrappedData),
             103 => Ok(TypeCode::ComplexObj),
             101 => Ok(TypeCode::Null),
-            _ => Err(IgniteError::from(
+            _ => Err(Error::from(
                 format!("Cannot read TypeCode {}", value).as_str(),
             )),
         }
@@ -100,7 +100,7 @@ fn read_object(reader: &mut impl Read) -> Result<Option<()>> {
     let code = code?;
     match code {
         TypeCode::Null => Ok(Some(())),
-        _ => Err(IgniteError::from(
+        _ => Err(Error::from(
             format!("Cannot read TypeCode {}", flag).as_str(),
         )),
     }
@@ -133,7 +133,7 @@ pub fn read_wrapped_data_dyn(
             let _offset = read_i32(reader)?;
             value
         }
-        _ => Err(IgniteError::from("Data is not wrapped!")),
+        _ => Err(Error::from("Data is not wrapped!")),
     }
 }
 

--- a/ignite-rs_derive/src/lib.rs
+++ b/ignite-rs_derive/src/lib.rs
@@ -105,7 +105,7 @@ fn impl_read_type(type_name: &Ident, fields: &FieldsNamed) -> TokenStream {
 
     quote! {
             impl ignite_rs::ReadableType for #type_name {
-            fn read_unwrapped(type_code: ignite_rs::protocol::TypeCode, reader: &mut impl std::io::Read) -> ignite_rs::error::IgniteResult<Option<Self>> {
+            fn read_unwrapped(type_code: ignite_rs::protocol::TypeCode, reader: &mut impl std::io::Read) -> ignite_rs::error::Result<Option<Self>> {
                 let value: Option<Self> = match type_code {
                     ignite_rs::protocol::TypeCode::Null => None,
                     _ => {

--- a/ignite-rs_derive/src/lib.rs
+++ b/ignite-rs_derive/src/lib.rs
@@ -113,18 +113,18 @@ fn impl_read_type(type_name: &Ident, fields: &FieldsNamed) -> TokenStream {
 
                         let flags = ignite_rs::protocol::read_u16(reader)?; // read and parse flags
                         if (flags & ignite_rs::protocol::FLAG_HAS_SCHEMA) == 0 {
-                            return Err(ignite_rs::error::IgniteError::from("Serialized object schema expected!"));
+                            return Err(ignite_rs::error::Error::from("Serialized object schema expected!"));
                         }
                         if (flags & ignite_rs::protocol::FLAG_COMPACT_FOOTER) != 0 {
-                            return Err(ignite_rs::error::IgniteError::from("Compact footer is not supported!"));
+                            return Err(ignite_rs::error::Error::from("Compact footer is not supported!"));
                         }
                         if (flags & ignite_rs::protocol::FLAG_OFFSET_ONE_BYTE) != 0 || (flags & ignite_rs::protocol::FLAG_OFFSET_TWO_BYTES) != 0 {
-                            return Err(ignite_rs::error::IgniteError::from("Schema offset=4 is expected!"));
+                            return Err(ignite_rs::error::Error::from("Schema offset=4 is expected!"));
                         }
 
                         let type_id = ignite_rs::protocol::read_i32(reader)?; // read and check type_id
                         if type_id != #exp_type_id {
-                            return Err(ignite_rs::error::IgniteError::from(
+                            return Err(ignite_rs::error::Error::from(
                                 format!("Unknown type id! {} expected!", #exp_type_id).as_str(),
                             ));
                         }


### PR DESCRIPTION
We're running into errors that look like this in garfield so I want to make the ignite error more descriptive.

```
2025-03-04T17:49:05Z [PID:1] ERROR garfield::collectors::ignite - Error while processing chunk 1 (chunk size: 1804012) for table SQL_BASE_STORAGE_SLOT_UPDATES: ignite Cache::put_all error

Caused by:
    Resource temporarily unavailable (os error 11)

Stack backtrace:
   0: garfield::collectors::ignite::IgniteConnection::put_all
   1: garfield::collectors::ignite::IgniteCollector::put_all::{{closure}}::{{closure}}
   2: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
   3: tokio::runtime::task::core::Core<T,S>::poll
   4: tokio::runtime::task::harness::Harness<T,S>::poll
   5: tokio::runtime::blocking::pool::Inner::run
   6: std::sys::backtrace::__rust_begin_short_backtrace
   7: core::ops::function::FnOnce::call_once{{vtable.shim}}
   8: std::sys::pal::unix::thread::Thread::new::thread_start
   9: <unknown>
  10: <unknown>
```

Not sure where in the put_all method the error is happening so I added error handling around the lock